### PR TITLE
fix: create output parent directory if missing

### DIFF
--- a/pkg/output/file.go
+++ b/pkg/output/file.go
@@ -36,6 +36,12 @@ func (c *FileConfig) UpdateSealedSecret(
 			return nil
 		}
 	}
+	// Create parent directory if it doesn't exist
+	if _, err := os.Stat(path.Dir(c.getFilePath())); os.IsNotExist(err) {
+		if err := os.MkdirAll(path.Dir(c.getFilePath()), 0755); err != nil {
+			return err
+		}
+	}
 	output, err := os.OpenFile(c.getFilePath(), os.O_RDWR|os.O_CREATE, 0644)
 	if err != nil {
 		return err


### PR DESCRIPTION
**Description of the change**

This PR improves the sealed secrets updater to ensure it creates the output parent directory if it's missing.

**Benefits**

Avoid errors such as the one below when the output file's parent directory doesn't exist:

```
F1010 16:20:24.676928   94074 main.go:49] unable to update sealed secrets: open /path/to/file.json: no such file or directory
```

**Possible drawbacks**

None

**Applicable issues**

N/A

**Additional information**

N/A
