### PR TITLE
feat: add support for secrets inputs in CSV

### DIFF
--- a/pkg/input/file.go
+++ b/pkg/input/file.go
@@ -1,9 +1,13 @@
 package input
 
 import (
+	"encoding/csv"
 	"encoding/json"
+	"fmt"
+	"io"
 	"os"
 	"path"
+	"strings"
 
 	"gopkg.in/yaml.v2"
 )
@@ -22,16 +26,9 @@ func (c *FileConfig) GetSecretsData() (map[string]string, error) {
 	}
 	defer inputFile.Close()
 
-	var secretsData map[string]string
-	switch c.getFormat() {
-	case "yaml":
-		if err := yaml.NewDecoder(inputFile).Decode(&secretsData); err != nil {
-			return nil, err
-		}
-	default:
-		if err := json.NewDecoder(inputFile).Decode(&secretsData); err != nil {
-			return nil, err
-		}
+	secretsData, err := getSecretsDataFromFile(inputFile, c.getFormat())
+	if err != nil {
+		return nil, err
 	}
 
 	return secretsData, nil
@@ -39,11 +36,14 @@ func (c *FileConfig) GetSecretsData() (map[string]string, error) {
 
 // getFormat returns the sealed secret format based on the file extension
 func (c *FileConfig) getFormat() string {
-	if ext := path.Ext(c.Path); ext == ".yaml" || ext == ".yml" {
+	switch strings.ToLower(path.Ext(c.Path)) {
+	case ".yaml", ".yml":
 		return "yaml"
+	case ".csv":
+		return "csv"
+	default:
+		return "json"
 	}
-
-	return "json"
 }
 
 // getFilePath returns the input file path
@@ -58,4 +58,35 @@ func (c *FileConfig) getFilePath() string {
 	}
 
 	return c.Path
+}
+
+// getSecretsDataFromFile returns the secrets data from the given file path
+func getSecretsDataFromFile(r io.Reader, format string) (map[string]string, error) {
+	var secretsData map[string]string
+	switch format {
+	case "yaml":
+		if err := yaml.NewDecoder(r).Decode(&secretsData); err != nil {
+			return nil, err
+		}
+	case "csv":
+		reader := csv.NewReader(r)
+		reader.FieldsPerRecord = 2
+		records, err := reader.ReadAll()
+		if err != nil {
+			return nil, err
+		}
+
+		secretsData = make(map[string]string, len(records))
+		for _, record := range records {
+			secretsData[record[0]] = record[1]
+		}
+	case "json":
+		if err := json.NewDecoder(r).Decode(&secretsData); err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unsupported input file format: %s", format)
+	}
+
+	return secretsData, nil
 }

--- a/pkg/input/file_test.go
+++ b/pkg/input/file_test.go
@@ -1,0 +1,114 @@
+package input
+
+import (
+	"io"
+	"reflect"
+	"strings"
+	"testing"
+)
+
+func Test_getSecretsDataFromFile(t *testing.T) {
+	type args struct {
+		r      io.Reader
+		format string
+	}
+	tests := []struct {
+		name    string
+		args    args
+		want    map[string]string
+		wantErr bool
+	}{
+		{
+			name: "valid yaml input",
+			args: args{
+				r: strings.NewReader(`key1: value1
+key2: value2`),
+				format: "yaml",
+			},
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid yaml input",
+			args: args{
+				r: strings.NewReader(`key1: value1
+key2 value2`),
+				format: "yaml",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "valid csv input",
+			args: args{
+				r: strings.NewReader(`key1,value1
+key2,value2`),
+				format: "csv",
+			},
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid csv input",
+			args: args{
+				r: strings.NewReader(`key1,value1
+key2,value2,value3`),
+				format: "csv",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "valid json input",
+			args: args{
+				r:      strings.NewReader(`{"key1":"value1","key2":"value2"}`),
+				format: "json",
+			},
+			want: map[string]string{
+				"key1": "value1",
+				"key2": "value2",
+			},
+			wantErr: false,
+		},
+		{
+			name: "invalid json input",
+			args: args{
+				r:      strings.NewReader(`{"key1":"value1","key2":"value2"`),
+				format: "json",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "unsupported properties format",
+			args: args{
+				r: strings.NewReader(`key1 = value1
+key2 = value2`),
+				format: "properties",
+			},
+			want:    nil,
+			wantErr: true,
+		},
+	}
+	t.Parallel()
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			got, err := getSecretsDataFromFile(test.args.r, test.args.format)
+			if (err != nil) != test.wantErr {
+				tt.Errorf("getSecretsDataFromFile() error = %v, wantErr %v", err, test.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(got, test.want) {
+				tt.Errorf("getSecretsDataFromFile() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/output/file.go
+++ b/pkg/output/file.go
@@ -7,6 +7,7 @@ import (
 	"encoding/json"
 	"os"
 	"path"
+	"strings"
 
 	ssv1alpha1 "github.com/bitnami-labs/sealed-secrets/pkg/apis/sealedsecrets/v1alpha1"
 	"github.com/bitnami-labs/sealed-secrets/pkg/kubeseal"
@@ -65,11 +66,12 @@ func (c *FileConfig) UpdateSealedSecret(
 
 // getFormat returns the sealed secret format based on the file extension
 func (c *FileConfig) getFormat() string {
-	if ext := path.Ext(c.Path); ext == ".yaml" || ext == ".yml" {
+	switch strings.ToLower(path.Ext(c.Path)) {
+	case ".yaml", ".yml":
 		return "yaml"
+	default:
+		return "json"
 	}
-
-	return "json"
 }
 
 // getFilePath returns the output file path


### PR DESCRIPTION
**Description of the change**

This PR adds support for secrets inputs in CSV format.

**Benefits**

More flexibility for secrets inputs.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

N/A
