### PR TITLE
feat: add support for skipping certain secrets

### DIFF
--- a/cmd/sealed-secrets-updater/update.go
+++ b/cmd/sealed-secrets-updater/update.go
@@ -10,6 +10,8 @@ import (
 	"github.com/juan131/sealed-secrets-updater/pkg/updater"
 )
 
+var skipSecrets []string
+
 // newCmdUpdate creates a command object for the "update" action.
 func newCmdUpdate() *cobra.Command {
 	cmd := &cobra.Command{
@@ -28,7 +30,7 @@ func newCmdUpdate() *cobra.Command {
 				return fmt.Errorf("invalid config: %w", err)
 			}
 
-			if err := updater.UpdateSealedSecrets(context.Background(), config); err != nil {
+			if err := updater.UpdateSealedSecrets(context.Background(), config, skipSecrets); err != nil {
 				return fmt.Errorf("unable to update sealed secrets: %w", err)
 			}
 
@@ -37,6 +39,8 @@ func newCmdUpdate() *cobra.Command {
 		SilenceErrors: true,
 		SilenceUsage:  true,
 	}
+
+	cmd.Flags().StringSliceVar(&skipSecrets, "skip-secrets", []string{}, "List of secrets to skip updating")
 
 	return cmd
 }

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -43,3 +43,13 @@ func StructToMapStringInterface(s interface{}) (map[string]interface{}, error) {
 
 	return mapVal, nil
 }
+
+// StringSliceContains is a helper function to detect whether a string slice contains a string or not
+func StringSliceContains(s []string, e string) bool {
+	for _, a := range s {
+		if a == e {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -30,7 +30,6 @@ type jsonSubStruct struct {
 }
 
 func Test_MapStringInterfaceToStruct(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		m map[string]interface{}
 		s interface{}
@@ -92,6 +91,7 @@ func Test_MapStringInterfaceToStruct(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	t.Parallel()
 	for _, testToRun := range tests {
 		test := testToRun
 		t.Run(test.name, func(tt *testing.T) {
@@ -107,7 +107,6 @@ func Test_MapStringInterfaceToStruct(t *testing.T) {
 }
 
 func TestStructToMapStringInterface(t *testing.T) {
-	t.Parallel()
 	type args struct {
 		s interface{}
 	}
@@ -163,6 +162,7 @@ func TestStructToMapStringInterface(t *testing.T) {
 			wantErr: false,
 		},
 	}
+	t.Parallel()
 	for _, testToRun := range tests {
 		test := testToRun
 		t.Run(test.name, func(tt *testing.T) {
@@ -174,6 +174,45 @@ func TestStructToMapStringInterface(t *testing.T) {
 			}
 			if !reflect.DeepEqual(got, test.want) {
 				tt.Errorf("StructToMapStringInterface() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}
+
+func TestStringSliceContains(t *testing.T) {
+	type args struct {
+		s []string
+		e string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Successful search",
+			args: args{
+				s: []string{"one", "two", "three"},
+				e: "two",
+			},
+			want: true,
+		},
+		{
+			name: "Unsuccessful search",
+			args: args{
+				s: []string{"one", "two", "three"},
+				e: "four",
+			},
+			want: false,
+		},
+	}
+	t.Parallel()
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			if got := StringSliceContains(test.args.s, test.args.e); got != test.want {
+				tt.Errorf("StringSliceContains() = %v, want %v", got, test.want)
 			}
 		})
 	}

--- a/pkg/updater/update.go
+++ b/pkg/updater/update.go
@@ -18,7 +18,7 @@ import (
 
 // UpdateSealedSecrets iterates over all the secrets in the secrets manager and
 // updates the sealed secrets manifests
-func UpdateSealedSecrets(ctx context.Context, config *config.Config) error {
+func UpdateSealedSecrets(ctx context.Context, config *config.Config, skipSecrets []string) error {
 	k8sConfig := k8s.NewClientConfig()
 	klog.Info("Obtaining public key...")
 	pubKey, err := getPublicKey(ctx, k8sConfig, config.KubesealConfig)
@@ -28,6 +28,11 @@ func UpdateSealedSecrets(ctx context.Context, config *config.Config) error {
 
 	klog.Info("Updating sealed secrets...")
 	for _, secret := range config.Secrets {
+		if utils.StringSliceContains(skipSecrets, secret.Name) {
+			klog.Infof("=> Skipping sealed secret \"%s\"", secret.Name)
+			continue
+		}
+
 		klog.Infof("=> Updating sealed secret \"%s\"", secret.Name)
 		var secretsData map[string]string
 		switch secret.Input.Type {


### PR DESCRIPTION
**Description of the change**

This PR adds support for skipping certain secrets while updating.

**Benefits**

Avoid updating manifests when there's no need for it (e.g. if only certain inputs were updated).

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

N/A
