### PR TITLE
feat: add support for listing only secrets to update

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,9 +19,6 @@ report.xml
 dist/
 out/
 
-# Local binaries
-sealed-secrets-updater
-
 # Dependency directories (remove the comment below to include it)
 # vendor/
 

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -6,7 +6,7 @@ builds:
     id: sealed-secrets-updater
     main: ./cmd/sealed-secrets-updater
     ldflags:
-      - -X main.VERSION={{ .Version }}
+      - -X main.Version={{ .Version }}
     targets:
       - darwin_amd64
       - darwin_arm64

--- a/cmd/sealed-secrets-updater/validate.go
+++ b/cmd/sealed-secrets-updater/validate.go
@@ -35,5 +35,11 @@ func newCmdValidate() *cobra.Command {
 		SilenceUsage:  true,
 	}
 
+	// Flags common to all sub commands
+	cmd.PersistentFlags().StringVar(&configPath, "config", "", "Path to config file")
+	if err := cmd.MarkPersistentFlagRequired("config"); err != nil {
+		klog.Fatal(err)
+	}
+
 	return cmd
 }

--- a/cmd/sealed-secrets-updater/version.go
+++ b/cmd/sealed-secrets-updater/version.go
@@ -1,0 +1,20 @@
+package main
+
+import (
+	"github.com/spf13/cobra"
+)
+
+// newCmdVersion creates a command object for the "version" action.
+func newCmdVersion() *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "version",
+		Short: "Print sealed-secrets-updater version",
+		Run: func(cmd *cobra.Command, args []string) {
+			root := cmd.Root()
+			root.SetArgs([]string{"--version"})
+			root.Execute()
+		},
+	}
+
+	return cmd
+}

--- a/go.mod
+++ b/go.mod
@@ -5,7 +5,6 @@ go 1.20
 require (
 	github.com/bitnami-labs/sealed-secrets v0.23.0
 	github.com/spf13/cobra v1.7.0
-	github.com/spf13/pflag v1.0.5
 	github.com/xeipuuv/gojsonschema v1.2.0
 	gopkg.in/yaml.v2 v2.4.0
 	k8s.io/api v0.27.4
@@ -36,6 +35,7 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
+	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/xeipuuv/gojsonpointer v0.0.0-20180127040702-4e3ac2762d5f // indirect
 	github.com/xeipuuv/gojsonreference v0.0.0-20180127040603-bd5ef7bd5415 // indirect
 	golang.org/x/crypto v0.14.0 // indirect

--- a/internal/utils/utils.go
+++ b/internal/utils/utils.go
@@ -53,3 +53,15 @@ func StringSliceContains(s []string, e string) bool {
 	}
 	return false
 }
+
+// StringSliceContainsAll is a helper function to detect whether a string slice contains all elements of a second string slice
+func StringSliceContainsAll(s []string, ref []string) bool {
+	allContained := true
+	for _, a := range s {
+		if !StringSliceContains(ref, a) {
+			allContained = false
+			break
+		}
+	}
+	return allContained
+}

--- a/internal/utils/utils_test.go
+++ b/internal/utils/utils_test.go
@@ -217,3 +217,42 @@ func TestStringSliceContains(t *testing.T) {
 		})
 	}
 }
+
+func TestStringSliceContainsAll(t *testing.T) {
+	type args struct {
+		s   []string
+		ref []string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Successful search",
+			args: args{
+				s:   []string{"one", "two"},
+				ref: []string{"one", "two", "three"},
+			},
+			want: true,
+		},
+		{
+			name: "Unsuccessful search",
+			args: args{
+				s:   []string{"one", "four"},
+				ref: []string{"one", "two", "three"},
+			},
+			want: false,
+		},
+	}
+	t.Parallel()
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			if got := StringSliceContainsAll(test.args.s, test.args.ref); got != test.want {
+				tt.Errorf("StringSliceContainsAll() = %v, want %v", got, test.want)
+			}
+		})
+	}
+}

--- a/pkg/updater/filter.go
+++ b/pkg/updater/filter.go
@@ -1,0 +1,35 @@
+package updater
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/juan131/sealed-secrets-updater/internal/utils"
+	"github.com/juan131/sealed-secrets-updater/pkg/config"
+)
+
+// Filter is used to filter the secrets to update
+type Filter struct {
+	OnlySecrets []string
+	SkipSecrets []string
+}
+
+// Validate validates the filter
+func (f Filter) Validate(secrets []*config.Secret) error {
+	for _, secret := range f.OnlySecrets {
+		if utils.StringSliceContains(f.SkipSecrets, secret) {
+			return fmt.Errorf("secret \"%s\" cannot be in both --only-secrets and --skip-secrets lists", secret)
+		}
+	}
+
+	existingSecrets := make([]string, 0, len(secrets))
+	for _, secret := range secrets {
+		existingSecrets = append(existingSecrets, secret.Name)
+	}
+
+	if !utils.StringSliceContainsAll(f.OnlySecrets, existingSecrets) {
+		return errors.New("some secrets in --only-secrets list do not exist")
+	}
+
+	return nil
+}

--- a/pkg/updater/filter_test.go
+++ b/pkg/updater/filter_test.go
@@ -1,0 +1,86 @@
+package updater
+
+import (
+	"testing"
+
+	"github.com/juan131/sealed-secrets-updater/pkg/config"
+)
+
+func TestFilter_Validate(t *testing.T) {
+	type fields struct {
+		OnlySecrets []string
+		SkipSecrets []string
+	}
+	type args struct {
+		secrets []*config.Secret
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
+	}{
+		{
+			"Valid filters",
+			fields{
+				OnlySecrets: []string{"secret1"},
+				SkipSecrets: []string{"secret2"},
+			},
+			args{
+				secrets: []*config.Secret{{
+					Name: "secret1",
+				}, {
+					Name: "secret2",
+				}},
+			},
+			false,
+		},
+		{
+			"OnlySecrets and SkipSecrets are empty",
+			fields{},
+			args{
+				secrets: []*config.Secret{{
+					Name: "secret1",
+				}},
+			},
+			false,
+		},
+		{
+			"OnlySecrets is set and some secrets do not exist",
+			fields{
+				OnlySecrets: []string{"secret1"},
+			},
+			args{
+				secrets: []*config.Secret{{}},
+			},
+			true,
+		},
+		{
+			"OnlySecrets & SkipSecrets are set and some secrets are in both lists",
+			fields{
+				OnlySecrets: []string{"secret1"},
+				SkipSecrets: []string{"secret1"},
+			},
+			args{
+				secrets: []*config.Secret{{
+					Name: "secret1",
+				}},
+			},
+			true,
+		},
+	}
+	t.Parallel()
+	for _, testToRun := range tests {
+		test := testToRun
+		t.Run(test.name, func(tt *testing.T) {
+			tt.Parallel()
+			f := Filter{
+				OnlySecrets: test.fields.OnlySecrets,
+				SkipSecrets: test.fields.SkipSecrets,
+			}
+			if err := f.Validate(test.args.secrets); (err != nil) != test.wantErr {
+				t.Errorf("Filter.Validate() error = %v, wantErr %v", err, test.wantErr)
+			}
+		})
+	}
+}


### PR DESCRIPTION
**Description of the change**

This PR adds support for listing only secrets to update (instead of updating every secret listed in the configuration). It also adds support for `version` subcommand.

**Benefits**

Filtering secrets to update.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

N/A
