### PR TITLE
fix: filters conditions

### DIFF
--- a/pkg/updater/update.go
+++ b/pkg/updater/update.go
@@ -32,7 +32,7 @@ func UpdateSealedSecrets(ctx context.Context, config *config.Config, filter Filt
 
 	klog.Info("Updating sealed secrets...")
 	for _, secret := range config.Secrets {
-		if !utils.StringSliceContains(filter.OnlySecrets, secret.Name) ||
+		if ((len(filter.OnlySecrets) > 0) && !utils.StringSliceContains(filter.OnlySecrets, secret.Name)) ||
 			utils.StringSliceContains(filter.SkipSecrets, secret.Name) {
 			klog.Infof("=> Skipping sealed secret \"%s\"", secret.Name)
 			continue


### PR DESCRIPTION
**Description of the change**

This PR fixes filters conditions since we're always skipping secrets updates when "OnlySecrets" is empty.

**Benefits**

`0.4.0` was useless unless `--only-secrets` was used due to the wrong conditions.

**Possible drawbacks**

None

**Applicable issues**

None

**Additional information**

N/A
